### PR TITLE
allow esbuild and sharp build scripts for pnpm

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,9 @@
         "sharp": "^0.34.5",
         "tailwindcss": "^4.1.17"
     },
+    "pnpm": {
+        "onlyBuiltDependencies": ["esbuild", "sharp"]
+    },
     "devDependencies": {
         "@tailwindcss/typography": "^0.5.19",
         "prettier": "^3.6.2",


### PR DESCRIPTION
pnpm v9+ blocks install scripts by default; explicitly allow esbuild and sharp which require them to build native binaries.