### PR TITLE
move pnpm onlyBuiltDependencies to pnpm-workspace.yaml

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,9 +21,6 @@
         "sharp": "^0.34.5",
         "tailwindcss": "^4.1.17"
     },
-    "pnpm": {
-        "onlyBuiltDependencies": ["esbuild", "sharp"]
-    },
     "devDependencies": {
         "@tailwindcss/typography": "^0.5.19",
         "prettier": "^3.6.2",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+onlyBuiltDependencies:
+  - esbuild
+  - sharp


### PR DESCRIPTION
pnpm v10 no longer reads the pnpm field in package.json; settings like onlyBuiltDependencies now belong in pnpm-workspace.yaml.