### PR TITLE
pin pnpm to v9 to fix ignored build scripts error

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,7 +29,7 @@ jobs:
               with:
                   path: . # root of your Astro project
                   node-version: 24
-                  package-manager: pnpm@latest
+                  package-manager: pnpm@9
                   build-cmd: pnpm run build
               env:
                   PUBLIC_POKEAPI: 'https://pokeapi.co/api/v2' # optional env

--- a/package.json
+++ b/package.json
@@ -21,6 +21,9 @@
         "sharp": "^0.34.5",
         "tailwindcss": "^4.1.17"
     },
+    "pnpm": {
+        "onlyBuiltDependencies": ["esbuild", "sharp"]
+    },
     "devDependencies": {
         "@tailwindcss/typography": "^0.5.19",
         "prettier": "^3.6.2",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,0 @@
-onlyBuiltDependencies:
-  - esbuild
-  - sharp


### PR DESCRIPTION
pnpm@latest resolved to v10 which dropped support for the pnpm field in package.json, causing esbuild and sharp build scripts to be blocked. Pinning to pnpm@9 restores the known-working configuration.