### PR TITLE
move @tailwindcss/typography to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
         "@astrojs/sitemap": "^3.6.0",
         "@fontsource-variable/inter": "^5.2.8",
         "@fontsource-variable/newsreader": "^5.2.10",
+        "@tailwindcss/typography": "^0.5.19",
         "@tailwindcss/vite": "^4.1.17",
         "astro": "^5.15.9",
         "marked": "^17.0.0",
@@ -25,7 +26,6 @@
         "onlyBuiltDependencies": ["esbuild", "sharp"]
     },
     "devDependencies": {
-        "@tailwindcss/typography": "^0.5.19",
         "prettier": "^3.6.2",
         "prettier-plugin-astro": "^0.14.1",
         "prettier-plugin-tailwindcss": "^0.7.1",


### PR DESCRIPTION
pnpm skips devDependencies when NODE_ENV=production, causing the build to fail when resolving @tailwindcss/typography from global.css.